### PR TITLE
More ristretto255 test vectors

### DIFF
--- a/site/test_vectors/ristretto255.md
+++ b/site/test_vectors/ristretto255.md
@@ -71,7 +71,17 @@ let bad_encodings = [
     "f4a9e534fc0d216c44b218fa0c42d99635a0127ee2e53c712f70609649fdff22",
     "8268436f8c4126196cf64b3c7ddbda90746a378625f9813dd9b8457077256731",
     "2810e5cbc2cc4d4eece54f61c6f69758e289aa7ab440b3cbeaa21995c2f4232b",
-    // More bad encodings... these should hit each of the 4 checks.
+    // This is s = -1, which causes y = 0.
+    "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+    // These are all bad because they give a negative xy value.
+    "3eb858e78f5a7254d8c9731174a94f76755fd3941c0ac93735c07ba14579630e",
+    "a45fdc55c76448c049a1ab33f17023edfb2be3581e9c7aade8a6125215e04220",
+    "d483fe813c6ba647ebbfd3ec41adca1c6130c2beeee9d9bf065c8d151c5f396e",
+    "8a2e1d30050198c65a54483123960ccc38aef6848e1ec8f5f780e8523769ba32",
+    "32888462f8b486c68ad7dd9610be5192bbeaf3b443951ac1a8118419d9fa097b",
+    "227142501b9d4355ccba290404bde41575b037693cef1f438c47f8fbf35d1165",
+    "5c37cc491da847cfeb9281d407efc41e15144c876e0170b499a96a22ed31e01e",
+    "445425117cb8c90edcbc7c1cc0e74f747f2c1efa5630a967c64f287792a48a4b",
 ];
 
 // Test that all of the bad encodings are rejected

--- a/site/test_vectors/ristretto255.md
+++ b/site/test_vectors/ristretto255.md
@@ -52,6 +52,7 @@ for i in 0..16 {
 }
 
 // The following are invalid encodings, which should all be rejected.
+// These are designed to test each of the checks during decoding.
 
 let bad_encodings = [
     // These are all bad because they're non-canonical field encodings.
@@ -62,6 +63,12 @@ let bad_encodings = [
     // These are all bad because they're negative field elements.
     "0100000000000000000000000000000000000000000000000000000000000000",
     "01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+    "ed57ffd8c914fb201471d1c3d245ce3c746fcbe63a3679d51b6a516ebebe0e20",
+    "c34c4e1826e5d403b78e246e88aa051c36ccf0aafebffe137d148a2bf9104562",
+    "c940e5a4404157cfb1628b108db051a8d439e1a421394ec4ebccb9ec92a8ac78",
+    "47cfc5497c53dc8e61c91d17fd626ffb1c49e2bca94eed052281b510b1117a24",
+    "f1c6165d33367351b0da8f6e4511010c68174a03b6581212c71c0e1d026c3c72",
+    "87260f7a2f12495118360f02c26a470f450dadf34a413d21042b43b9d93e1309",
     // These are all bad because they give a nonsquare x^2.
     "26948d35ca62e643e26a83177332e6b6afeb9d08e4268b650f1f5bbd8d81d371",
     "4eac077a713c57b4f4397629a4145982c661f48044dd3f96427d40b147d9742f",
@@ -71,8 +78,6 @@ let bad_encodings = [
     "f4a9e534fc0d216c44b218fa0c42d99635a0127ee2e53c712f70609649fdff22",
     "8268436f8c4126196cf64b3c7ddbda90746a378625f9813dd9b8457077256731",
     "2810e5cbc2cc4d4eece54f61c6f69758e289aa7ab440b3cbeaa21995c2f4232b",
-    // This is s = -1, which causes y = 0.
-    "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
     // These are all bad because they give a negative xy value.
     "3eb858e78f5a7254d8c9731174a94f76755fd3941c0ac93735c07ba14579630e",
     "a45fdc55c76448c049a1ab33f17023edfb2be3581e9c7aade8a6125215e04220",
@@ -82,6 +87,8 @@ let bad_encodings = [
     "227142501b9d4355ccba290404bde41575b037693cef1f438c47f8fbf35d1165",
     "5c37cc491da847cfeb9281d407efc41e15144c876e0170b499a96a22ed31e01e",
     "445425117cb8c90edcbc7c1cc0e74f747f2c1efa5630a967c64f287792a48a4b",
+    // This is s = -1, which causes y = 0.
+    "ecffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
 ];
 
 // Test that all of the bad encodings are rejected

--- a/site/test_vectors/ristretto255.md
+++ b/site/test_vectors/ristretto255.md
@@ -62,6 +62,15 @@ let bad_encodings = [
     // These are all bad because they're negative field elements.
     "0100000000000000000000000000000000000000000000000000000000000000",
     "01ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff7f",
+    // These are all bad because they give a nonsquare x^2.
+    "26948d35ca62e643e26a83177332e6b6afeb9d08e4268b650f1f5bbd8d81d371",
+    "4eac077a713c57b4f4397629a4145982c661f48044dd3f96427d40b147d9742f",
+    "de6a7b00deadc788eb6b6c8d20c0ae96c2f2019078fa604fee5b87d6e989ad7b",
+    "bcab477be20861e01e4a0e295284146a510150d9817763caf1a6f4b422d67042",
+    "2a292df7e32cababbd9de088d1d1abec9fc0440f637ed2fba145094dc14bea08",
+    "f4a9e534fc0d216c44b218fa0c42d99635a0127ee2e53c712f70609649fdff22",
+    "8268436f8c4126196cf64b3c7ddbda90746a378625f9813dd9b8457077256731",
+    "2810e5cbc2cc4d4eece54f61c6f69758e289aa7ab440b3cbeaa21995c2f4232b",
     // More bad encodings... these should hit each of the 4 checks.
 ];
 


### PR DESCRIPTION
This fills in the bad encoding test vectors for `ristretto255`. With this addition, the list of bad encodings hits:

- the check that the field encoding is canonical;
- the three sign choices made when eliminating the cofactor of 8;
- the special case y = 0 that falls through the square root.