### PR TITLE
Update dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 authors = ["Henry de Valence <hdevalence@hdevalence.ca>", "Isis Lovecruft <isis@patternsinthevoid.net>", "Tony Arcieri <bascule@gmail.com>"]
 
 [dependencies]
-sha2 = "0.7"
+sha2 = "0.8"
 hex = "0.3"
-curve25519-dalek = "0.19"
+curve25519-dalek = "1"

--- a/site/test_vectors/ristretto255.md
+++ b/site/test_vectors/ristretto255.md
@@ -15,10 +15,11 @@ d\_2 = d &= -121665/121666.
 Field elements are considered negative when their low bit is set, as in Ed25519.
 The Elligator map uses \\(n = +\sqrt{-1}\\) as the quadratic nonresidue.
 
-
 ```rust
 // The test vectors below also have code to test them against the
 // curve25519_dalek implementation.
+//
+// These tests are run in CI against the curve25519-dalek implementation.
 
 extern crate sha2;
 extern crate hex;


### PR DESCRIPTION
I yanked old versions of `subtle` from crates.io, which broke the CI for the website, because it was still using old versions of `curve25519-dalek`: the system works!