### PR TITLE
Fix typos in Ristretto explicit decoding formulas

### DIFF
--- a/site/formulas/decoding.md
+++ b/site/formulas/decoding.md
@@ -7,14 +7,14 @@ follows.
 1. Check that `s_bytes` is the canonical encoding of a field element, or else abort.
 2. Decode `s_bytes`, a byte-string, into \\(s\\), a field element.
 3. Check that \\(s\\) is non-negative, or else abort.
-4. \\(u_1 \gets 1 - a s^{2} \\).
-5. \\(u_2 \gets 1 + a s^{2} \\).
+4. \\(u_1 \gets 1 + a s^{2} \\).
+5. \\(u_2 \gets 1 - a s^{2} \\).
 6. \\(v \gets adu_1^2 - u_2^2 \\).
-7. \\(I \gets \mathrm{invsqrt}( v u_1^{2} ) \\), or abort if the square root does not exist.
+7. \\(I \gets \mathrm{invsqrt}( v u_2^{2} ) \\), or abort if the square root does not exist.
 8. \\(D_x \gets I u_2 \\).
 9. \\(D_y \gets I D_x v \\).
 10. \\(x \gets |2 s D_x| \\), i.e., compute \\(2sD_x\\) and negate it if it is negative.
-11. Compute \\(y \gets u_2 D_y \\).
+11. Compute \\(y \gets u_1 D_y \\).
 12. Compute \\(t \gets x y \\).
 13. If \\( t \\) is negative or \\( y = 0 \\), abort.
     Otherwise, return the Ristretto point represented by


### PR DESCRIPTION
For some reason these were different than both the derivation and also the test vectors (which were correct).