### PR TITLE
implementations: link to `go-ristretto`

### DIFF
--- a/site/implementations.md
+++ b/site/implementations.md
@@ -5,8 +5,9 @@ Henry de Valence, Jack Grigg, George Tankersley, Filippo Valsorda, and
 Isis Lovecruft.
 
 * Rust: [`curve25519-dalek`][dalek], by Isis Lovecruft and Henry de Valence;
-* Go: `ristretto255` (forthcoming), by George Tankersley and Filippo Valsorda;
+* Go: [`go-ristretto`][go-ristretto] by Bas Westerbaan and `ristretto255` (forthcoming), by George Tankersley and Filippo Valsorda;
 * C: `ristretto-donna` (forthcoming), by Isis Lovecruft, based on Andrew Moon's `ed25519-donna`;
 
 [id]: https://datatracker.ietf.org/doc/draft-hdevalence-cfrg-ristretto/
 [dalek]: https://doc.dalek.rs/curve25519_dalek/
+[go-ristretto]: https://github.com/bwesterb/go-ristretto


### PR DESCRIPTION
Adds a link to [go-ristretto](https://github.com/bwesterb/go-ristretto).

It predates the RFC, but it is compatible.  There is one caveat: my `Point.Derive` is different from the RFC's `FROM_UNIFORM_BYTES`.  That one is implemented by my `Point.DeriveDalek` (as it appeared in curve25519-dalek already).  I documented that difference.

@gtank I'm open to merging `go-ristretto` into your project: having separate implementations isn't necessarily ideal.  (Or even better: try to get something into Go stdlib.)