### PR TITLE
ristretto255 is implemented in libsodium

### DIFF
--- a/site/implementations.md
+++ b/site/implementations.md
@@ -8,7 +8,7 @@ Isis Lovecruft.
 * Go: `ristretto255` (forthcoming), by George Tankersley and Filippo Valsorda;
 * C: `ristretto-donna` (forthcoming), by Isis Lovecruft, based on Andrew Moon's `ed25519-donna`;
 * C: [`libsodium`][libsodium] (currently in git master branch), by Frank Denis;
-* AssemblyScript: [`wasm-crypto`][wasm-crypto] (forthcoming), by Frank Denis;
+* AssemblyScript: [`wasm-crypto`][wasm-crypto], by Frank Denis;
 
 [id]: https://datatracker.ietf.org/doc/draft-hdevalence-cfrg-ristretto/
 [dalek]: https://doc.dalek.rs/curve25519_dalek/

--- a/site/implementations.md
+++ b/site/implementations.md
@@ -7,6 +7,10 @@ Isis Lovecruft.
 * Rust: [`curve25519-dalek`][dalek], by Isis Lovecruft and Henry de Valence;
 * Go: `ristretto255` (forthcoming), by George Tankersley and Filippo Valsorda;
 * C: `ristretto-donna` (forthcoming), by Isis Lovecruft, based on Andrew Moon's `ed25519-donna`;
+* C: [`libsodium`][libsodium] (currently in git master branch), by Frank Denis;
+* AssemblyScript: [`wasm-crypto`][wasm-crypto] (forthcoming), by Frank Denis;
 
 [id]: https://datatracker.ietf.org/doc/draft-hdevalence-cfrg-ristretto/
 [dalek]: https://doc.dalek.rs/curve25519_dalek/
+[libsodium]: https://libsodium.org
+[wasm-crypto]: https://github.com/jedisct1/wasm-crypto


### PR DESCRIPTION
In git for now - It will likely be part of libsodium 1.0.18.

An implementation in wasm-crypto will follow.

Update: Ristretto in wasm-crypto is done.